### PR TITLE
Add Links to the course material, Add TAs in the index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,39 @@
 
 ### Teaching Assistants: 
 * Ayush Shrivastava <shrivastavaayush@iitgn.ac.in>
-* More to be added soon
+* Risabh Mondal <rishabh.mondal@iitgn.ac.in>
+* Abhyudaya Nair <24210005@iitgn.ac.in>
+* Alay Patel <alay.patel@iitgn.ac.in>
+* Ashish Rawat <ashish.rawat@iitgn.ac.in>
+* Balkrishna Sehra <24210022@iitgn.ac.in>
+* Charan Teja <24210056@iitgn.ac.in>
+* Chetana Dubey <24250030@iitgn.ac.in>
+* Dekka Muni Kumar <24210028@iitgn.ac.in>
+* Dhruv Patel <dhruv.patel@iitgn.ac.in>
+* Diya <24210032@iitgn.ac.in>
+* Drishti <24210033@iitgn.ac.in>
+* Indrayudh	Mandal <24210041@iitgn.ac.in>
+* Jenil	Patel <24210048@iitgn.ac.in>
+* Kaloori Shiva Prasad <24250041@iitgn.ac.in>
+* Manish Bairwa	<manish.bairwa@iitgn.ac.in>
+* Mithlesh Singla <24210063@iitgn.ac.in>
+* Sawan	Verma <sawan.verma@iitgn.ac.in>
+* Shataxi Dubey <shataxi.dubey@iitgn.ac.in>
+* Shivansh Gupta <24250086@iitgn.ac.in>
+* Suruchi Hardaha <24250097@iitgn.ac.in>
+* Vinayak Rana <24210114@iitgn.ac.in>
+* Aadya Arora <aadya.arora@iitgn.ac.in>
+* Abhishek Kushwaha	<abhishek.kushwaha@iitgn.ac.in>
+* Aryan Sahu <aryan.sahu@iitgn.ac.in>
+* Bhavik Patel <bhavik.patel@iitgn.ac.in>
+* Bhoumik Patidar <bhoumik.patidar@iitgn.ac.in>
+* Dewansh Chandel <dewanshsingh.chandel@iitgn.ac.in>
+* Dewansh Kumar	<dewansh.kumar@iitgn.ac.in>
+* Guntas Singh Saran <guntassingh.saran@iitgn.ac.in>
+* Shreyans Jain <shreyans.jain@iitgn.ac.in>
+* Vamsi Srivathsa <vamsi.srivathsa@iitgn.ac.in>
+* Viraj Vekaria <viraj.vekaria@iitgn.ac.in>
+* Yash Bachwana <yash.bachwana@iitgn.ac.in>
 
 ### Class Venue and Timings:
 * Lecture : Jasubhai Auditorium, Tuesdays, 10:00 AM - 11:20 AM

--- a/index.qmd
+++ b/index.qmd
@@ -51,8 +51,8 @@ title: "ES 114 Probability, Statistics and Data Visualization"
     * Guntas Singh Saran <guntassingh.saran@iitgn.ac.in>
     * Shreyans Jain <shreyans.jain@iitgn.ac.in>
     * Vamsi Srivathsa <vamsi.srivathsa@iitgn.ac.in>
-    * Viraj	Vekaria <viraj.vekaria@iitgn.ac.in>
-    * Yash Bachwana	<yash.bachwana@iitgn.ac.in>
+    * Viraj Vekaria <viraj.vekaria@iitgn.ac.in>
+    * Yash Bachwana <yash.bachwana@iitgn.ac.in>
 
 * Class Venue and Timings:
     * Lecture : Jasubhai Auditorium, Monday, 8:30 AM - 10:00 AM (A1 slot)

--- a/index.qmd
+++ b/index.qmd
@@ -20,7 +20,39 @@ title: "ES 114 Probability, Statistics and Data Visualization"
 
 * Teaching Assistants: 
     * Ayush Shrivastava <shrivastavaayush@iitgn.ac.in>
-    * More to be added soon
+    * Risabh Mondal <rishabh.mondal@iitgn.ac.in>
+    * Abhyudaya Nair <24210005@iitgn.ac.in>
+    * Alay Patel <alay.patel@iitgn.ac.in>
+    * Ashish Rawat <ashish.rawat@iitgn.ac.in>
+    * Balkrishna Sehra <24210022@iitgn.ac.in>
+    * Charan Teja <24210056@iitgn.ac.in>
+    * Chetana Dubey <24250030@iitgn.ac.in>
+    * Dekka Muni Kumar <24210028@iitgn.ac.in>
+    * Dhruv Patel <dhruv.patel@iitgn.ac.in>
+    * Diya <24210032@iitgn.ac.in>
+    * Drishti <24210033@iitgn.ac.in>
+    * Indrayudh	Mandal <24210041@iitgn.ac.in>
+    * Jenil	Patel <24210048@iitgn.ac.in>
+    * Kaloori Shiva Prasad <24250041@iitgn.ac.in>
+    * Manish Bairwa	<manish.bairwa@iitgn.ac.in>
+    * Mithlesh Singla <24210063@iitgn.ac.in>
+    * Sawan	Verma <sawan.verma@iitgn.ac.in>
+    * Shataxi Dubey <shataxi.dubey@iitgn.ac.in>
+    * Shivansh Gupta <24250086@iitgn.ac.in>
+    * Suruchi Hardaha <24250097@iitgn.ac.in>
+    * Vinayak Rana <24210114@iitgn.ac.in>
+    * Aadya Arora <aadya.arora@iitgn.ac.in>
+    * Abhishek Kushwaha	<abhishek.kushwaha@iitgn.ac.in>
+    * Aryan Sahu <aryan.sahu@iitgn.ac.in>
+    * Bhavik Patel <bhavik.patel@iitgn.ac.in>
+    * Bhoumik Patidar <bhoumik.patidar@iitgn.ac.in>
+    * Dewansh Chandel <dewanshsingh.chandel@iitgn.ac.in>
+    * Dewansh Kumar	<dewansh.kumar@iitgn.ac.in>
+    * Guntas Singh Saran <guntassingh.saran@iitgn.ac.in>
+    * Shreyans Jain <shreyans.jain@iitgn.ac.in>
+    * Vamsi Srivathsa <vamsi.srivathsa@iitgn.ac.in>
+    * Viraj	Vekaria <viraj.vekaria@iitgn.ac.in>
+    * Yash Bachwana	<yash.bachwana@iitgn.ac.in>
 
 * Class Venue and Timings:
     * Lecture : Jasubhai Auditorium, Monday, 8:30 AM - 10:00 AM (A1 slot)

--- a/schedule.qmd
+++ b/schedule.qmd
@@ -26,8 +26,5 @@ Content will get added here as the course progresses
 |7| 21 Jan 2025| Set Theory|[Notebook](https://nipunbatra.github.io/psdv-teaching/notebooks/set.html), [Slides](https://probability4datascience.com/slides/Slide_2_01.pdf)|
 |8| 22 Jan 2025| Lab 2: Pandas (continued)|
 |9| 23 Jan 2025| Jupyter Widgets| [Notebook](https://nipunbatra.github.io/psdv-teaching/notebooks/widgets.html), [YouTube](https://www.youtube.com/watch?v=BJAaZaKxf00)
-|9| 23 Jan 2025| More Set Theory Questions | [Colab](https://colab.research.google.com/drive/1RrjF2VZDcst0iUgW5zrpsBy-VWUfjtkJ?usp=sharing)
-|10| 27 Jan 2025| Probability|[Notebook](), [Slides]()|
-
-
-
+|10| 23 Jan 2025| More Set Theory Questions | [Colab](https://colab.research.google.com/drive/1RrjF2VZDcst0iUgW5zrpsBy-VWUfjtkJ?usp=sharing)
+|11| 27 Jan 2025| Probability|

--- a/schedule.qmd
+++ b/schedule.qmd
@@ -7,7 +7,7 @@ title: "Lectures"
 
 * [Github repo containing source code for lectures and notebooks](https://github.com/nipunbatra/psdv-teaching)
 * [Rendered Lecture notebooks](https://nipunbatra.github.io/psdv-teaching/notebooks.html)
-* [YouTube playlist containing recodings](https://www.youtube.com/watch?v=CAzR00au0T0&list=PLftoLyLEwECCTFpc8_-gV8NqG_LgdL3Uy&index=1) 
+* [YouTube playlist containing recordings](https://www.youtube.com/watch?v=CAzR00au0T0&list=PLftoLyLEwECCTFpc8_-gV8NqG_LgdL3Uy&index=1) 
 
 Content will get added here as the course progresses
 
@@ -19,13 +19,15 @@ Content will get added here as the course progresses
 |     0     | 06 Jan 2025 | Introduction and Logistics |           |   Slides, Notebook|         
 |1| 07 Jan 2025| NumPy| [Notebook](https://nipunbatra.github.io/psdv-teaching/notebooks/intro-numpy.html), [Youtube](https://www.youtube.com/watch?v=CAzR00au0T0)|
 |2| 08 Jan 2025| Lab 1: NumPy| [Colab](https://colab.research.google.com/drive/169vg_FV35sJ8irVXU82RrTwlR762Ph2g?usp=sharing)|
-|3| 13 Jan 2025| Pandas| [Notebook](), [Youtube]()|
-|4| 14 Jan 2025| Matplotlib| [Notebook](), [Youtube]()|
+|3| 13 Jan 2025| Pandas| [Notebook](https://nipunbatra.github.io/psdv-teaching/notebooks/introduction-pandas.html), [Youtube](https://www.youtube.com/watch?v=iaQDhwFkAhA)|
+|4| 14 Jan 2025| Matplotlib| [Notebook](https://nipunbatra.github.io/psdv-teaching/notebooks/introduction-matplotlib.html), [Youtube](https://www.youtube.com/watch?v=ERu46g5EzVk)|
 |5| 15 Jan 2025| Lab Viva 1|
-|6| 20 Jan 2025| Lab 2: Pandas| [Colab]()|
-|7| 21 Jan 2025| Set theory|[Notebook](), [Slides]()|
+|6| 20 Jan 2025| Lab 2: Pandas| [Colab](https://colab.research.google.com/drive/1pmt8hSfwzhp8ke3uXsGrOt4XELdoTmr1?usp=sharing)|
+|7| 21 Jan 2025| Set Theory|[Notebook](https://nipunbatra.github.io/psdv-teaching/notebooks/set.html), [Slides]()|
 |8| 22 Jan 2025| Lab 2: Pandas (continued)|
-|9| 27 Jan 2025| Probability|[Notebook](), [Slides]()|
+|9| 23 Jan 2025| Jupyter Widgets| [Notebook](https://nipunbatra.github.io/psdv-teaching/notebooks/widgets.html), [YouTube](https://www.youtube.com/watch?v=BJAaZaKxf00)
+|9| 23 Jan 2025| More Set Theory Questions | [Colab](https://colab.research.google.com/drive/1RrjF2VZDcst0iUgW5zrpsBy-VWUfjtkJ?usp=sharing)
+|10| 27 Jan 2025| Probability|[Notebook](), [Slides]()|
 
 
 

--- a/schedule.qmd
+++ b/schedule.qmd
@@ -23,7 +23,7 @@ Content will get added here as the course progresses
 |4| 14 Jan 2025| Matplotlib| [Notebook](https://nipunbatra.github.io/psdv-teaching/notebooks/introduction-matplotlib.html), [Youtube](https://www.youtube.com/watch?v=ERu46g5EzVk)|
 |5| 15 Jan 2025| Lab Viva 1|
 |6| 20 Jan 2025| Lab 2: Pandas| [Colab](https://colab.research.google.com/drive/1pmt8hSfwzhp8ke3uXsGrOt4XELdoTmr1?usp=sharing)|
-|7| 21 Jan 2025| Set Theory|[Notebook](https://nipunbatra.github.io/psdv-teaching/notebooks/set.html), [Slides]()|
+|7| 21 Jan 2025| Set Theory|[Notebook](https://nipunbatra.github.io/psdv-teaching/notebooks/set.html), [Slides](https://probability4datascience.com/slides/Slide_2_01.pdf)|
 |8| 22 Jan 2025| Lab 2: Pandas (continued)|
 |9| 23 Jan 2025| Jupyter Widgets| [Notebook](https://nipunbatra.github.io/psdv-teaching/notebooks/widgets.html), [YouTube](https://www.youtube.com/watch?v=BJAaZaKxf00)
 |9| 23 Jan 2025| More Set Theory Questions | [Colab](https://colab.research.google.com/drive/1RrjF2VZDcst0iUgW5zrpsBy-VWUfjtkJ?usp=sharing)


### PR DESCRIPTION
`schedule.qmd`:
- Added the links to the Rendered Notebooks, Colab, Slides, and YouTube recorded lectures.

`index.qmd`
- Added the List of TAs in the lexicographical order + PG-UG manner.